### PR TITLE
Load saved settings when mod loads

### DIFF
--- a/HttpServer.cs
+++ b/HttpServer.cs
@@ -14,8 +14,8 @@ namespace DvMod.RadioBridge
         {
             if (!listener.IsListening)
             {
-                listener.Prefixes.Add($"http://*:{Main.settings.serverPort}/");
-                Main.DebugLog(() => $"Starting HTTP server on port {Main.settings.serverPort}");
+                listener.Prefixes.Add($"http://*:{Main.Settings.serverPort}/");
+                Main.DebugLog(() => $"Starting HTTP server on port {Main.Settings.serverPort}");
                 listener.Start();
             }
 

--- a/Main.cs
+++ b/Main.cs
@@ -8,11 +8,12 @@ namespace DvMod.RadioBridge
     public static class Main
     {
         public static UnityModManager.ModEntry? mod;
-        public static readonly Settings settings = new Settings();
+        public static Settings Settings { get; private set; } = new Settings();
 
         static public bool Load(UnityModManager.ModEntry modEntry)
         {
             mod = modEntry;
+            try { Settings = Settings.Load<Settings>(modEntry); } catch {}
 
             modEntry.OnGUI = OnGUI;
             modEntry.OnSaveGUI = OnSaveGUI;
@@ -23,12 +24,12 @@ namespace DvMod.RadioBridge
 
         static private void OnGUI(UnityModManager.ModEntry modEntry)
         {
-            settings.Draw();
+            Settings.Draw();
         }
 
         static private void OnSaveGUI(UnityModManager.ModEntry modEntry)
         {
-            settings.Save(modEntry);
+            Settings.Save(modEntry);
         }
 
         static private bool OnToggle(UnityModManager.ModEntry modEntry, bool value)
@@ -50,19 +51,19 @@ namespace DvMod.RadioBridge
 
         public static void DebugLog(string msg)
         {
-            if (settings.enableLogging)
+            if (Settings.enableLogging)
                 mod!.Logger.Log(msg);
         }
 
         public static void DebugLog(Func<string> msg)
         {
-            if (settings.enableLogging)
+            if (Settings.enableLogging)
                 DebugLog(msg());
         }
 
         public static void DebugLog(Func<string> msg, Exception e)
         {
-            if (settings.enableLogging)
+            if (Settings.enableLogging)
                 mod!.Logger.LogException(msg(), e);
         }
     }

--- a/Playlists.cs
+++ b/Playlists.cs
@@ -15,7 +15,7 @@ namespace DvMod.RadioBridge
             PlsPlaylistEntry entry = new PlsPlaylistEntry()
             {
                 Title = Main.mod!.Info.DisplayName,
-                Path = $"http://localhost:{Main.settings.serverPort}",
+                Path = $"http://localhost:{Main.Settings.serverPort}",
                 Nr = pls.PlaylistEntries.Last().Nr + 1,
             };
             pls.PlaylistEntries.Add(entry);

--- a/Recording.cs
+++ b/Recording.cs
@@ -30,7 +30,7 @@ namespace DvMod.RadioBridge
             for (int i = 0; i < WaveInEvent.DeviceCount; i++)
             {
                 var deviceInfo = WaveInEvent.GetCapabilities(i);
-                if (deviceInfo.ProductName.Equals(Main.settings.inputDeviceName))
+                if (deviceInfo.ProductName.Equals(Main.Settings.inputDeviceName))
                     return i;
             }
             return -1;
@@ -40,7 +40,7 @@ namespace DvMod.RadioBridge
         {
             var deviceId = FindInputDevice();
             if (deviceId < 0)
-                throw new Exception($"Could not find input device: \"{Main.settings.inputDeviceName}\"");
+                throw new Exception($"Could not find input device: \"{Main.Settings.inputDeviceName}\"");
             encoder = new Encoder();
             waveIn.DeviceNumber = deviceId;
             waveIn.WaveFormat = new WaveFormat(48000, 2);


### PR DESCRIPTION
Changed `Main.settings` to a property (and thus changed casing) to preserve the readonly behavior outside the Main class. It can't be readonly anymore because it must be assigned to in order to load the saved values.

Confirmed by observing the selected audio device persist between game launches.

Closes #1.