### PR TITLE
Allow radio stream time to recover from CPU load

### DIFF
--- a/Recording.cs
+++ b/Recording.cs
@@ -47,14 +47,14 @@ namespace DvMod.RadioBridge
             waveIn.DataAvailable += OnDataAvailable;
             waveIn.RecordingStopped += OnRecordingStopped;
             waveIn.StartRecording();
-            Main.DebugLog(() => $"Started recording from device {waveIn.DeviceNumber} ({WaveInEvent.GetCapabilities(waveIn.DeviceNumber).ProductName})");
+            Main.DebugLog(() => $"Started capturing from device {waveIn.DeviceNumber} ({WaveInEvent.GetCapabilities(waveIn.DeviceNumber).ProductName})");
         }
 
         public void StopCapture()
         {
             waveIn.StopRecording();
             encoder!.Flush(output!);
-            Main.DebugLog(() => $"Stopped recording from device {waveIn.DeviceNumber} ({WaveInEvent.GetCapabilities(waveIn.DeviceNumber).ProductName})");
+            Main.DebugLog(() => $"Stopped capturing from device {waveIn.DeviceNumber} ({WaveInEvent.GetCapabilities(waveIn.DeviceNumber).ProductName})");
         }
 
         private void OnDataAvailable(object sender, WaveInEventArgs args)
@@ -68,6 +68,8 @@ namespace DvMod.RadioBridge
             output.Close();
             if (args.Exception != null && !(args.Exception is SocketException))
                 Main.DebugLog(() => "Recording stopped with exception:", args.Exception);
+            else
+                Main.DebugLog(() => "Recording stopped");
         }
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -11,6 +11,10 @@ namespace DvMod.RadioBridge
         public int serverPort = 7100;
         [Draw("Enable logging")]
         public bool enableLogging = true;
+        [Draw("Seconds to wait for the data stream to recover before stopping playback")]
+        public int recoveryTimeout = 2;
+        [Draw("Milliseconds after which the recovery timeout will be reset if no errors have occurred")]
+        public int recoveryReset = 500;
 
         public readonly string? version = Main.mod?.Info.Version;
 

--- a/StreamRecovery.cs
+++ b/StreamRecovery.cs
@@ -1,0 +1,43 @@
+using DV.Radio;
+using HarmonyLib;
+using System;
+
+namespace DvMod.RadioBridge
+{
+    [HarmonyPatch(typeof(RadioPlayer), "LogNoMoreData")]
+    static class StreamRecovery
+    {
+        static DateTime startTime;
+        static DateTime lastTime;
+
+        static bool Prefix()
+        {
+            if (lastTime == null)
+                lastTime = DateTime.Now;
+
+            if (startTime == null)
+            {
+                startTime = lastTime;
+                return false; // skip the original method in which playback is stopped
+            }
+
+            DateTime now = DateTime.Now;
+
+            if ((now - lastTime).TotalMilliseconds > Main.Settings.recoveryReset)
+            {
+                startTime = lastTime = now;
+                return false; // skip the original method in which playback is stopped
+            }
+
+            lastTime = now;
+
+            if ((now - startTime).TotalMilliseconds < Main.Settings.recoveryTimeout * 1000)
+            {
+                return false; // skip the original method in which playback is stopped
+            }
+
+            // Reaching this point means the recovery timeout has been exceeded
+            return true; // run the original method in which playback is stopped
+        }
+    }
+}


### PR DESCRIPTION
Vanilla behavior is for radio playback to stop as soon as zero length data is read from the response stream. This change introduces a timeout period during which radio playback will continue to be attempted. If the response stream continues to not deliver data for longer than the timeout period, playback will be stopped. If the response stream delivers data for a specified duration, it will be considered recovered, and the timeout will restart. Both timeout and recovery durations are configurable via mod settings.

Tested by comparison against published version of Radio Bridge during high CPU load simulated with [CpuStres](https://learn.microsoft.com/en-us/sysinternals/downloads/cpustres). The published version eventually stopped within 5 minutes of CPU load start shortly after audio glitches were heard. With these changes, audio glitches were occasionally heard, but playback continued for 10+ minutes after CPU load start. If necessary, further tuning can be accomplished by the player via the mod settings.

CpuStres settings:
![image](https://github.com/mspielberg/dv-radio-bridge/assets/66900153/a7fc12ac-6d30-4ffd-8952-15e48ae7fab7)
